### PR TITLE
Update abstract to 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,18 +5,40 @@ version = 3
 [[package]]
 name = "abstract-account-factory"
 version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-macros 0.13.0",
  "abstract-sdk 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "abstract-account-factory"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3a21c44d8c054c7b43cdb7219702c077eb3c9cbfa6b15a73c4ceaf1d8c099f"
+dependencies = [
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf",
  "semver",
  "serde",
@@ -25,18 +47,18 @@ dependencies = [
 
 [[package]]
 name = "abstract-ans-host"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011e10ca8af13556ee33c7b43628df816aae07396e6c1d7c6375ab39c07f3e20"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
+ "abstract-core 0.13.0",
+ "abstract-macros 0.13.0",
+ "abstract-sdk 0.13.0",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-ownable",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver",
  "serde",
  "thiserror",
@@ -44,17 +66,19 @@ dependencies = [
 
 [[package]]
 name = "abstract-ans-host"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8330f852958a8037c323935dd9d952e9e66ab660e22b59613e29ccbbe141087"
 dependencies = [
- "abstract-core",
- "abstract-macros 0.13.0",
- "abstract-sdk 0.13.0",
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-ownable",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver",
  "serde",
  "thiserror",
@@ -63,15 +87,15 @@ dependencies = [
 [[package]]
 name = "abstract-api"
 version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-sdk 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
  "thiserror",
@@ -79,24 +103,23 @@ dependencies = [
 
 [[package]]
 name = "abstract-boot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee709fb951196f6b9bfccc3ee195b629d80284fcf0b20cf493b85ac89a84e3f5"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-ans-host 0.12.0",
- "abstract-manager 0.12.0",
- "abstract-module-factory 0.12.0",
- "abstract-os",
- "abstract-os-factory",
- "abstract-proxy 0.12.0",
- "abstract-version-control 0.12.0",
- "boot-core",
+ "abstract-account-factory 0.13.0",
+ "abstract-ans-host 0.13.0",
+ "abstract-core 0.13.0",
+ "abstract-manager 0.13.0",
+ "abstract-module-factory 0.13.0",
+ "abstract-proxy 0.13.0",
+ "abstract-version-control 0.13.0",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "schemars",
  "semver",
@@ -109,23 +132,24 @@ dependencies = [
 
 [[package]]
 name = "abstract-boot"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d35e516210921fa31077543fe8bca2897d802a75d169eef4e1fa1026aecb76"
 dependencies = [
- "abstract-account-factory",
- "abstract-ans-host 0.13.0",
- "abstract-core",
- "abstract-manager 0.13.0",
- "abstract-module-factory 0.13.0",
- "abstract-proxy 0.13.0",
- "abstract-version-control 0.13.0",
- "boot-core",
+ "abstract-account-factory 0.13.2",
+ "abstract-ans-host 0.13.2",
+ "abstract-core 0.13.2",
+ "abstract-manager 0.13.2",
+ "abstract-module-factory 0.13.2",
+ "abstract-proxy 0.13.2",
+ "abstract-version-control 0.13.2",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "schemars",
  "semver",
@@ -139,20 +163,48 @@ dependencies = [
 [[package]]
 name = "abstract-core"
 version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
  "abstract-ica 0.13.0",
- "boot-core",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-address-like",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-ownable",
  "cw-semver",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20-base 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "abstract-core"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711c40a6d83b099efdc991497025f23ed62146a65f17513fb28556bff837c55a"
+dependencies = [
+ "abstract-ica 0.13.2",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-address-like",
+ "cw-asset",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-ownable",
+ "cw-semver",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20-base 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -161,9 +213,8 @@ dependencies = [
 
 [[package]]
 name = "abstract-ica"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e180d1fd424c65f608cf285c95d14710bdd84d4098b73c66ee8349bc45739bb"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -174,8 +225,9 @@ dependencies = [
 
 [[package]]
 name = "abstract-ica"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ce17d4dcd9c5dcbc834461696cbed912ddb76915383e4b1b2c5f4106ac3e75"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -186,9 +238,8 @@ dependencies = [
 
 [[package]]
 name = "abstract-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f181d2710741c377e9374b45d16bef2a42530e46199ab4089546456c5676d25"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -197,8 +248,9 @@ dependencies = [
 
 [[package]]
 name = "abstract-macros"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aa7e0b9495c7b412a7b872a30416b299a0f3afab975e42f77306a12bd4eed2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -207,21 +259,20 @@ dependencies = [
 
 [[package]]
 name = "abstract-manager"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d304a5a4282725cd84dc7e2d7ebf6c771a16dc5555c745fbd16aebdc2a1bae"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
+ "abstract-core 0.13.0",
+ "abstract-macros 0.13.0",
+ "abstract-sdk 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-semver",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -230,20 +281,21 @@ dependencies = [
 
 [[package]]
 name = "abstract-manager"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3228465bc271dea525f108a50c7c6381f750710d67ecf16dba24b6d58957fa62"
 dependencies = [
- "abstract-core",
- "abstract-macros 0.13.0",
- "abstract-sdk 0.13.0",
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-semver",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -252,19 +304,18 @@ dependencies = [
 
 [[package]]
 name = "abstract-module-factory"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226eb80e7cb984f8887b25aa287078a108f5f23c360f0bbd6d73f294d770f1b8"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
+ "abstract-core 0.13.0",
+ "abstract-macros 0.13.0",
+ "abstract-sdk 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf",
  "semver",
  "thiserror",
@@ -272,85 +323,39 @@ dependencies = [
 
 [[package]]
 name = "abstract-module-factory"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef7713203b34bd49de3e2af1dd72fb322a986b0f0215e847b2111cb4b3195e35"
 dependencies = [
- "abstract-core",
- "abstract-macros 0.13.0",
- "abstract-sdk 0.13.0",
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf",
  "semver",
- "thiserror",
-]
-
-[[package]]
-name = "abstract-os"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b71081515639313ad5f9e4402318e1177ee72cab6c0f05faa6c9b5f1a9f096"
-dependencies = [
- "abstract-ica 0.11.0",
- "boot-core",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-asset",
- "cw-controllers 1.0.1",
- "cw-semver",
- "cw-storage-plus 1.0.1",
- "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "abstract-os-factory"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ff1edda3800bcb580b318e36a771ee126ff1d9028a65e882a4aad46bccca04"
-dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-asset",
- "cw-controllers 1.0.1",
- "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
- "protobuf",
- "semver",
- "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "abstract-proxy"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c75f025504e0789bac301e4db779f78d24e2abfe38bcdb5effb656a0f38a0fc"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
+ "abstract-core 0.13.0",
+ "abstract-macros 0.13.0",
+ "abstract-sdk 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -359,39 +364,20 @@ dependencies = [
 
 [[package]]
 name = "abstract-proxy"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51cff9284c9ef6bda480cee5ea9a8d67d706bfa83ff94142574b6435ece2422d"
 dependencies = [
- "abstract-core",
- "abstract-macros 0.13.0",
- "abstract-sdk 0.13.0",
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
- "schemars",
- "semver",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "abstract-sdk"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420e0d148b15b7b1b54095a12d1455e10ef42ccd9cacd03020d7755740a468a5"
-dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "cosmwasm-std",
- "cw-asset",
- "cw-controllers 1.0.1",
- "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -401,18 +387,38 @@ dependencies = [
 [[package]]
 name = "abstract-sdk"
 version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-macros 0.13.0",
  "abstract-testing",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "abstract-sdk"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc01aace4fd5c01086b777090952c0f98c7453c69dd938fffc96aa9b9be52b8"
+dependencies = [
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -422,14 +428,14 @@ dependencies = [
 [[package]]
 name = "abstract-testing"
 version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-core",
+ "abstract-core 0.13.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder",
  "schemars",
  "serde",
@@ -439,35 +445,35 @@ dependencies = [
 
 [[package]]
 name = "abstract-version-control"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b01ab2582ba7c9e16391c864874ea08d3f8bf3707fef9ad68b369df662510"
+version = "0.13.0"
+source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
 dependencies = [
- "abstract-macros 0.11.0",
- "abstract-os",
- "abstract-sdk 0.12.0",
+ "abstract-core 0.13.0",
+ "abstract-macros 0.13.0",
+ "abstract-sdk 0.13.0",
  "cosmwasm-std",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-semver",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "abstract-version-control"
-version = "0.13.0"
-source = "git+https://github.com/Abstract-OS/contracts.git#57b76a9ea58e2944e37b2b5b0cac48ae0295cc9e"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a70cb95f26033457a9809d14c53c42d421097307200ca7a8b6ff6cc596efa8"
 dependencies = [
- "abstract-core",
- "abstract-macros 0.13.0",
- "abstract-sdk 0.13.0",
+ "abstract-core 0.13.2",
+ "abstract-macros 0.13.2",
+ "abstract-sdk 0.13.2",
  "cosmwasm-std",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-semver",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror",
 ]
@@ -478,7 +484,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -499,6 +505,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -535,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -546,31 +592,31 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "async-tungstenite"
-version = "0.17.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
+checksum = "1e0388bb7a400072bbb41ceb75d65c3baefb2ea99672fa22e85278452cd9b58b"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -590,13 +636,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -653,12 +699,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -695,32 +735,37 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.29.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
 dependencies = [
  "bech32",
+ "bitcoin-private",
  "bitcoin_hashes",
+ "hex_lit",
  "secp256k1",
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
+name = "bitcoin-private"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "block-buffer"
@@ -742,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "boot-contract-derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6710d266d584cbd27ed9ad98b03beba25cc6312decf53e165954acc7334e5286"
+checksum = "b6d5010efb5d2f121985dca0aa92acd3fce48bcdfc99f6b11a0464e8aeaf717d"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -752,13 +797,13 @@ dependencies = [
 
 [[package]]
 name = "boot-core"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1da1a219c4d6b79f133f836e032bce4cda4bb0998c95bc3fe6ac7dfb50cd2"
+checksum = "f94dfd762791312c37914087fc3771ec827e27295b87e5c941a904f9791cceb8"
 dependencies = [
  "anyhow",
  "base16",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bitcoin",
  "boot-contract-derive",
  "boot-fns-derive",
@@ -776,7 +821,8 @@ dependencies = [
  "prost 0.11.8",
  "rand_core 0.6.4",
  "reqwest",
- "rust-crypto",
+ "ring",
+ "ripemd",
  "schemars",
  "secp256k1",
  "serde",
@@ -788,26 +834,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "boot-cw-plus"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137e2961f843b421fb0bfc5f6bf1e029d01812a9360251ac3bc6693198eb00a"
+name = "boot-core"
+version = "0.10.0"
+source = "git+https://github.com/Abstract-OS/BOOT.git#3b5653f4461c44ad42c97314ff71838382fc8586"
 dependencies = [
  "anyhow",
- "boot-core",
+ "boot-contract-derive",
+ "boot-fns-derive",
  "cosmwasm-std",
  "cw-multi-test",
+ "log",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "boot-cw-plus"
+version = "0.10.0"
+source = "git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0#3a9215020d1bf0592b940f59b09650a6d5b75137"
+dependencies = [
+ "anyhow",
+ "boot-core 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git)",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw1",
+ "cw1-subkeys",
  "cw1-whitelist",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20-base 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20-ics20",
+ "cw3",
+ "cw3-fixed-multisig",
+ "cw3-flex-multisig",
+ "cw4",
+ "cw4-group",
+ "cw4-stake",
+ "serde",
+]
+
+[[package]]
+name = "boot-cw-plus"
+version = "0.10.0"
+source = "git+https://github.com/Abstract-OS/BOOT.git#3b5653f4461c44ad42c97314ff71838382fc8586"
+dependencies = [
+ "anyhow",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw1",
+ "cw1-subkeys",
+ "cw1-whitelist",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20-base 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20-ics20",
+ "cw3",
+ "cw3-fixed-multisig",
+ "cw3-flex-multisig",
+ "cw4",
+ "cw4-group",
+ "cw4-stake",
  "serde",
 ]
 
 [[package]]
 name = "boot-fns-derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b4307f1c27ffe0dcdfa63882069bdc1f8c3246e706a4b1ce45e126a1ff4bcf"
+checksum = "d393ab931ab528220197c7fe9bfc361f0a0459743d4dd49211cec86ee1d70232"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -874,40 +969,45 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.11"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
- "bitflags 2.0.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -917,6 +1017,21 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -946,49 +1061,49 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b42021d8488665b1a0d9748f1f81df7235362d194f44481e2e61bf376b77b4"
+checksum = "ade369159e0256ae10c6fb5f16decc37129d6b2416710456185daacfa65bdfae"
 dependencies = [
  "prost 0.11.8",
  "prost-types",
- "tendermint-proto 0.23.9",
+ "tendermint-proto",
  "tonic",
 ]
 
 [[package]]
 name = "cosmrs"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3903590099dcf1ea580d9353034c9ba1dbf55d1389a5bd2ade98535c3445d1f9"
+checksum = "466426988551efa4cce46bac51ce6b6e047ea7b76086ac5e47bffad90a3c093e"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "k256",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint 0.23.9",
- "tendermint-rpc 0.23.9",
+ "tendermint",
+ "tendermint-rpc",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8263ce52392898aa17c2a0984b7c542df416e434f6e0cb1c1a11771054d159"
+checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -999,18 +1114,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1895f6d7a191bb044e3c555190d1da555c2571a3af41f849f60c855580e392f"
+checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b99f612ccf162940ae2eef9f370ee37cf2ddcf4a9a8f5ee15ec6b46a5ecd2e"
+checksum = "fe5ad2e23a971b9e4cd57b20cee3e2e79c33799bed4b128e473aca3702bfe5dd"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -1021,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92ceea61033cb69c336abf673da017ddf251fc4e26e0cdd387eaf8bedb14e49"
+checksum = "2926d159a9bb1a716a592b40280f1663f2491a9de3b6da77c0933cee2a2655b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1032,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc01051aab3bb88d5efe0b90f24a6df1ca96a873b12fc21b862b17539c84ee9"
+checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
 dependencies = [
  "base64 0.13.1",
  "cosmwasm-crypto",
@@ -1052,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719b9895ef880f172bfe698c975aa6ce5712abb2d0162148d51f346706df80"
+checksum = "639bc36408bc1ac45e3323166ceeb8f0b91b55a941c4ad59d389829002fbbd94"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -1062,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1120,6 +1235,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cw-address-like"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,7 +1266,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-address-like",
  "cw-storage-plus 1.0.1",
- "cw20 1.0.1",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -1172,10 +1300,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-controllers"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw-multi-test"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eb84554bbfa6b66736abcd6a9bfdf237ee0ecb83910f746dff7f799093c80a"
+checksum = "d09dcedf6e747839af86de6eec7678ea9d41e8b5675391e19b2eace9b3e87da1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1191,6 +1333,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-ownable"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093dfb4520c48b5848274dd88ea99e280a04bc08729603341c7fb0d758c74321"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-address-like",
+ "cw-ownable-derive",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-ownable-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d3bf2e0f341bb6cc100d7d441d31cf713fbd3ce0c511f91e79f14b40a889af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cw-placeholder"
 version = "1.1.2"
 source = "git+https://github.com/cosmorama/wynddex.git?rev=v1.1.2#acca3311673d9d7c990a88d910f4a03a9acf25fd"
@@ -1198,7 +1366,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -1217,22 +1385,23 @@ version = "0.11.0"
 dependencies = [
  "abstract-api",
  "abstract-boot 0.13.0",
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-sdk 0.13.0",
  "abstract-testing",
  "anyhow",
  "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=126d43216111df786472fe2a845c1e2fadfe4a36)",
- "boot-core",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
  "clap",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-staking",
  "cw-utils 0.13.4",
  "cw-utils 1.0.1",
  "cw20 0.10.3",
- "cw20 1.0.1",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw20-stake",
  "dotenv",
  "env_logger",
@@ -1314,7 +1483,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -1336,9 +1505,9 @@ dependencies = [
 [[package]]
 name = "cw1"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3391aa03144be4f8fad7a59bcb803d4f71d80c82a724eee2c4cd903dfb3df88f"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
 dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "schemars",
@@ -1346,17 +1515,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw1-whitelist"
+name = "cw1-subkeys"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69521e2f9d5f32e2c2690d1b84d33ade4e43ddaff94cdbed20bb3588cc5d0821"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
 dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
  "cw1",
- "cw2 1.0.1",
+ "cw1-whitelist",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw1-whitelist"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
  "schemars",
  "serde",
  "thiserror",
@@ -1412,6 +1600,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw20"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1642,19 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91666da6c7b40c8dd5ff94df655a28114efc10c79b70b4d06f13c31e37d60609"
 dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 1.0.1",
@@ -1490,8 +1704,45 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-base"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-ics20"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
  "schemars",
  "semver",
  "serde",
@@ -1517,10 +1768,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw3"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.1",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw3-fixed-multisig"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw3",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw3-flex-multisig"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw3",
+ "cw3-fixed-multisig",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw4"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw4-group"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw4-stake"
+version = "1.0.1"
+source = "git+https://github.com/Abstract-OS/cw-plus.git#914729bbee842d2f79651b6024d634f1d53fec2f"
+dependencies = [
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1530,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1540,24 +1893,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1664,19 +2017,20 @@ version = "0.11.0"
 dependencies = [
  "abstract-api",
  "abstract-boot 0.13.0",
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-sdk 0.13.0",
  "abstract-testing",
  "anyhow",
  "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=7bedc6f27e59ef8b921a0980be9bc30c4aab7459)",
- "boot-core",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
  "clap",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
  "cw-storage-plus 1.0.1",
  "cw20 0.10.3",
- "cw20 1.0.1",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dex",
  "dotenv",
  "env_logger",
@@ -1745,6 +2099,19 @@ checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "serde",
  "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -1836,13 +2203,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1940,16 +2307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1962,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1972,15 +2333,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1989,38 +2350,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2035,16 +2396,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2063,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2120,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "headers-core",
  "http",
@@ -2164,6 +2519,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hkd32"
@@ -2330,16 +2691,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -2354,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-chain-registry"
-version = "0.2.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d756837118673a8da870180bb0ca13e6cc1bca01120d4cf82f1c6a8249ca01f"
+checksum = "c1c61ec20f3a311c7e7088f5726c1101d105523f04ef50561df0b5742d18b259"
 dependencies = [
  "async-trait",
  "flex-error",
@@ -2367,16 +2728,16 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tendermint-rpc 0.28.0",
+ "tendermint-rpc",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.24.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b46bcc4540116870cfb184f338b45174a7560ad46dd74e4cb4e81e005e2056"
+checksum = "40a2d356a360473d212dd20779b11ce858e35ac5509c7e1953002fa247780759"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -2384,15 +2745,15 @@ dependencies = [
  "prost 0.11.8",
  "serde",
  "subtle-encoding",
- "tendermint-proto 0.28.0",
+ "tendermint-proto",
  "tonic",
 ]
 
 [[package]]
 name = "ibc-relayer-types"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc7d3c48e9721152977e89446d3f5bc20ba8da29014d973545500fc8fdecf69"
+checksum = "05064fd47044b1de6e6dbf18389dbbb460664ce8d9f1ab1067e1fb5eb163854c"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2410,11 +2771,10 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "subtle-encoding",
- "tendermint 0.28.0",
+ "tendermint",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.28.0",
- "tendermint-rpc 0.28.0",
- "time 0.3.11",
+ "tendermint-proto",
+ "time 0.3.20",
  "uint",
 ]
 
@@ -2466,9 +2826,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2485,31 +2845,31 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd6da19f25979c7270e70fa95ab371ec3b701cd0eefc47667a09785b3c59155"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2566,9 +2926,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "link-cplusplus"
@@ -2581,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -2618,9 +2978,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -2750,15 +3110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,11 +3123,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2787,13 +3138,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2804,22 +3155,15 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "osmosis-std"
@@ -2895,7 +3239,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -3014,34 +3358,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -3121,29 +3441,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3188,21 +3485,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3216,7 +3498,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -3229,28 +3511,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3259,15 +3541,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3341,47 +3623,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time 0.1.45",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustix"
-version = "0.36.10"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3591,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
  "secp256k1-sys",
@@ -3601,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -3614,7 +3866,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3642,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -3678,13 +3930,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3700,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -3717,7 +3969,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3730,17 +3982,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -3895,6 +4136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3923,40 +4170,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tendermint"
-version = "0.23.9"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467f82178deeebcd357e1273a0c0b77b9a8a0313ef7c07074baebe99d87851f4"
+checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
 dependencies = [
- "async-trait",
  "bytes",
+ "digest 0.10.6",
  "ed25519",
- "ed25519-dalek",
+ "ed25519-consensus",
  "flex-error",
  "futures",
  "k256",
@@ -3964,94 +4199,52 @@ dependencies = [
  "once_cell",
  "prost 0.11.8",
  "prost-types",
- "ripemd160",
+ "ripemd",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.23.9",
- "time 0.3.11",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c518c082146825f10d6f9a32159ae46edcfd7dae8ac630c8067594bb2a784d72"
-dependencies = [
- "bytes",
- "ed25519",
- "ed25519-dalek",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost 0.11.8",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.9.9",
- "signature",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.28.0",
- "time 0.3.11",
+ "tendermint-proto",
+ "time 0.3.20",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.9"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42ee0abc27ef5fc34080cce8d43c189950d331631546e7dfb983b6274fa327"
+checksum = "74efd33bcb53413b77cbe90ccb2cf0403930a5c1f300725deb87a61f7c4fab90"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.23.9",
- "toml",
- "url",
-]
-
-[[package]]
-name = "tendermint-config"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f58b86374e3bcfc8135770a6c55388fce101c00de4a5f03224fa5830c9240b7"
-dependencies = [
- "flex-error",
- "serde",
- "serde_json",
- "tendermint 0.28.0",
+ "tendermint",
  "toml",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c742bb914f9fb025ce0e481fbef9bb59c94d5a4bbd768798102675a2e0fb7440"
+checksum = "f36e9193521a81e4c824faedc5eb31926f8918ebb21a1fa9cee9b3dbe5164a93"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint 0.28.0",
- "time 0.3.11",
+ "tendermint",
+ "time 0.3.20",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.23.9"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ce80bf536476db81ecc9ebab834dc329c9c1509a694f211a73858814bfe023"
+checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4062,87 +4255,37 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "time 0.3.11",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890f1fb6dee48900c85f0cdf711ebf130e505ac09ad918cee5c34ed477973b05"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost 0.11.8",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time 0.3.11",
+ "time 0.3.20",
 ]
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.9"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f14aafe3528a0f75e9f3f410b525617b2de16c4b7830a21f717eee62882ec60"
-dependencies = [
- "async-trait",
- "bytes",
- "flex-error",
- "futures",
- "getrandom 0.2.8",
- "http",
- "hyper",
- "hyper-proxy",
- "hyper-rustls 0.22.1",
- "peg",
- "pin-project",
- "serde",
- "serde_bytes",
- "serde_json",
- "subtle-encoding",
- "tendermint 0.23.9",
- "tendermint-config 0.23.9",
- "tendermint-proto 0.23.9",
- "thiserror",
- "time 0.3.11",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "tendermint-rpc"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06df4715f9452ec0a21885d6da8d804799455ba50d8bc40be1ec1c800afd4bd8"
+checksum = "d79bd426571d6a805be5c0b6749707ede6c6ee5e55dd45baef46857a1baa9f54"
 dependencies = [
  "async-trait",
  "async-tungstenite",
  "bytes",
  "flex-error",
  "futures",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "http",
  "hyper",
  "hyper-proxy",
  "hyper-rustls 0.22.1",
  "peg",
  "pin-project",
+ "semver",
  "serde",
  "serde_bytes",
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint 0.28.0",
- "tendermint-config 0.28.0",
+ "tendermint",
+ "tendermint-config",
  "thiserror",
- "time 0.3.11",
+ "time 0.3.20",
  "tokio",
  "tracing",
  "url",
@@ -4156,9 +4299,9 @@ version = "0.11.0"
 dependencies = [
  "abstract-api",
  "abstract-boot 0.13.0",
- "abstract-core",
+ "abstract-core 0.13.0",
  "abstract-sdk 0.13.0",
- "boot-core",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "thiserror",
@@ -4204,7 +4347,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4220,20 +4363,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "libc",
- "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -4252,14 +4404,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -4282,13 +4433,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4474,9 +4625,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -4486,7 +4637,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls 0.20.8",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -4513,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -4572,6 +4723,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -4809,18 +4966,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4829,7 +4995,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4838,13 +5013,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4854,10 +5044,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4866,10 +5068,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4878,16 +5092,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -4918,8 +5150,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20-base 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools",
  "thiserror",
  "uint",
@@ -4928,20 +5160,20 @@ dependencies = [
 [[package]]
 name = "wyndex-bundle"
 version = "0.2.0"
-source = "git+https://github.com/Abstract-OS/integration-bundles.git#c2816e638155b2f6a924e6789ce5cdbdcec76b19"
+source = "git+https://github.com/Abstract-OS/integration-bundles.git?branch=update/0.13.2#a405305176857772cbde576611e654720cf55783"
 dependencies = [
- "abstract-boot 0.12.0",
- "abstract-os",
+ "abstract-boot 0.13.2",
+ "abstract-core 0.13.2",
  "anyhow",
- "boot-core",
- "boot-cw-plus",
+ "boot-core 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git)",
+ "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git)",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-multi-test",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
+ "cw20 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
+ "cw20-base 1.0.1 (git+https://github.com/Abstract-OS/cw-plus.git)",
  "wyndex",
  "wyndex-factory",
  "wyndex-multi-hop",
@@ -4959,7 +5191,7 @@ dependencies = [
  "cw-placeholder",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools",
  "thiserror",
  "wyndex",
@@ -4974,8 +5206,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "wyndex",
 ]
@@ -4989,9 +5221,9 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
- "cw20-base 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20-base 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wyndex",
  "wyndex-stake",
 ]
@@ -5003,11 +5235,11 @@ source = "git+https://github.com/cosmorama/wynddex.git?rev=v1.1.2#acca3311673d9d
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers 1.0.1",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror",
  "wynd-utils",
@@ -5016,21 +5248,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.13",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "abstract-cw-staking-api"
+version = "0.11.0"
+dependencies = [
+ "abstract-api",
+ "abstract-boot 0.13.0",
+ "abstract-core 0.13.0",
+ "abstract-cw-staking-api",
+ "abstract-sdk 0.13.0",
+ "abstract-testing",
+ "anyhow",
+ "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=126d43216111df786472fe2a845c1e2fadfe4a36)",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
+ "clap",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.13.4",
+ "cw-utils 1.0.1",
+ "cw20 0.10.3",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20-stake",
+ "dotenv",
+ "env_logger",
+ "log",
+ "osmosis-std 0.12.0",
+ "schemars",
+ "semver",
+ "serde",
+ "speculoos",
+ "thiserror",
+ "tokio",
+ "wasmswap 1.1.2-beta",
+ "wyndex",
+ "wyndex-bundle",
+ "wyndex-stake",
+]
+
+[[package]]
+name = "abstract-dex-api"
+version = "0.11.0"
+dependencies = [
+ "abstract-api",
+ "abstract-boot 0.13.0",
+ "abstract-core 0.13.0",
+ "abstract-dex-api",
+ "abstract-sdk 0.13.0",
+ "abstract-testing",
+ "anyhow",
+ "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=7bedc6f27e59ef8b921a0980be9bc30c4aab7459)",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
+ "clap",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-storage-plus 1.0.1",
+ "cw20 0.10.3",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv",
+ "env_logger",
+ "osmosis-std 0.13.2",
+ "schemars",
+ "semver",
+ "serde",
+ "speculoos",
+ "terraswap",
+ "thiserror",
+ "tokio",
+ "wasmswap 1.2.0",
+ "wyndex",
+ "wyndex-bundle",
+]
+
+[[package]]
 name = "abstract-ica"
 version = "0.13.0"
 source = "git+https://github.com/Abstract-OS/contracts.git#bb4a72c754ed2a881822b6b5e5a12fc6b270258a"
@@ -422,6 +498,20 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "abstract-tendermint-staking-api"
+version = "0.11.0"
+dependencies = [
+ "abstract-api",
+ "abstract-boot 0.13.0",
+ "abstract-core 0.13.0",
+ "abstract-sdk 0.13.0",
+ "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
  "thiserror",
 ]
 
@@ -1380,46 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-staking"
-version = "0.11.0"
-dependencies = [
- "abstract-api",
- "abstract-boot 0.13.0",
- "abstract-core 0.13.0",
- "abstract-sdk 0.13.0",
- "abstract-testing",
- "anyhow",
- "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=126d43216111df786472fe2a845c1e2fadfe4a36)",
- "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
- "clap",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-asset",
- "cw-controllers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-staking",
- "cw-utils 0.13.4",
- "cw-utils 1.0.1",
- "cw20 0.10.3",
- "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw20-stake",
- "dotenv",
- "env_logger",
- "log",
- "osmosis-std 0.12.0",
- "schemars",
- "semver",
- "serde",
- "speculoos",
- "thiserror",
- "tokio",
- "wasmswap 1.1.2-beta",
- "wyndex",
- "wyndex-bundle",
- "wyndex-stake",
-]
-
-[[package]]
 name = "cw-storage-plus"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,42 +2059,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "dex"
-version = "0.11.0"
-dependencies = [
- "abstract-api",
- "abstract-boot 0.13.0",
- "abstract-core 0.13.0",
- "abstract-sdk 0.13.0",
- "abstract-testing",
- "anyhow",
- "astroport 2.0.0 (git+https://github.com/astroport-fi/astroport-core.git?rev=7bedc6f27e59ef8b921a0980be9bc30c4aab7459)",
- "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "boot-cw-plus 0.10.0 (git+https://github.com/Abstract-OS/BOOT.git?tag=v0.10.0)",
- "clap",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-asset",
- "cw-storage-plus 1.0.1",
- "cw20 0.10.3",
- "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dex",
- "dotenv",
- "env_logger",
- "osmosis-std 0.13.2",
- "schemars",
- "semver",
- "serde",
- "speculoos",
- "terraswap",
- "thiserror",
- "tokio",
- "wasmswap 1.2.0",
- "wyndex",
- "wyndex-bundle",
 ]
 
 [[package]]
@@ -4291,20 +4305,6 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
-]
-
-[[package]]
-name = "tendermint-staking"
-version = "0.11.0"
-dependencies = [
- "abstract-api",
- "abstract-boot 0.13.0",
- "abstract-core 0.13.0",
- "abstract-sdk 0.13.0",
- "boot-core 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cosmwasm-schema",
- "cosmwasm-std",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ protobuf = { version = "2", features = ["with-bytes"] }
 
 clap = { version = "4.0.32", features = ["derive"] }
 semver = "1.0"
-cw-semver = { version = "1.0"}
-boot-cw-plus = { version = "0.8.0" }
-boot-core = { version = "0.8.0" }
+cw-semver = { version = "1.0" }
+boot-cw-plus = { git = "https://github.com/Abstract-OS/BOOT.git", tag = "v0.10.0" }
+boot-core = { version = "0.10.0" }
 
 tokio = { version = "1.4", features = ["full"] }
 

--- a/contracts/cw-staking/Cargo.toml
+++ b/contracts/cw-staking/Cargo.toml
@@ -91,4 +91,5 @@ clap = { workspace = true }
 cw-staking = { path = "." , features = ["boot"]}
 abstract-sdk = { workspace = true, features = ["test-utils"] }
 abstract-testing = { workspace = true }
-wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git"}
+wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git", branch = "update/0.13.2" }
+boot-cw-plus = { workspace = true }

--- a/contracts/cw-staking/Cargo.toml
+++ b/contracts/cw-staking/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cw-staking"
+name = "abstract-cw-staking-api"
 description = "Cw-staking is a Abstract api for staking tokens."
 version.workspace = true
 authors.workspace = true
@@ -7,9 +7,9 @@ edition.workspace = true
 publish = false
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -26,12 +26,12 @@ export = []
 default = ["all", "export"]
 boot = ["dep:boot-core", "dep:abstract-boot"]
 juno = [
-  "dep:wasmswap",
-  "dep:cw20_junoswap",
-  "dep:cw20-stake",
-  "dep:wyndex",
-  "dep:wyndex-stake",
-  "dep:cw-controllers",
+    "dep:wasmswap",
+    "dep:cw20_junoswap",
+    "dep:cw20-stake",
+    "dep:wyndex",
+    "dep:wyndex-stake",
+    "dep:cw-controllers",
 ]
 # osmosis = ["dep:osmosis-std"]
 terra = ["dep:astroport"]
@@ -57,15 +57,15 @@ boot-core = { workspace = true, optional = true }
 
 # Juno dexes #
 cw20-stake = { git = "https://github.com/DA0-DA0/dao-contracts.git", optional = true, features = [
-  "library",
+    "library",
 ], tag = "v1.0.0" }
 cw20_junoswap = { package = "cw20", version = "0.10.0", optional = true }
 wasmswap = { git = "https://github.com/Wasmswap/wasmswap-contracts", tag = "v1.1.2-beta", features = [
-  "library",
+    "library",
 ], optional = true }
 wyndex = { git = "https://github.com/cosmorama/wynddex.git", rev = "v1.1.2", optional = true }
 wyndex-stake = { git = "https://github.com/cosmorama/wynddex.git", rev = "v1.1.2", optional = true, features = [
-  "library",
+    "library",
 ] }
 dao-cw-utils = { version = "0.13.4", package = "cw-utils" }
 
@@ -85,10 +85,10 @@ dotenv = "0.15.0"
 env_logger = "0.10.0"
 log = "0.4.14"
 speculoos = { workspace = true }
-boot-core = { workspace = true , features = ["daemon"] }
+boot-core = { workspace = true, features = ["daemon"] }
 abstract-boot = { workspace = true }
 clap = { workspace = true }
-cw-staking = { path = "." , features = ["boot"]}
+cw-staking = { path = ".", features = ["boot"], package = "abstract-cw-staking-api" }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
 abstract-testing = { workspace = true }
 wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git", branch = "update/0.13.2" }

--- a/contracts/cw-staking/examples/deploy.rs
+++ b/contracts/cw-staking/examples/deploy.rs
@@ -1,7 +1,9 @@
+use abstract_boot::boot_core::{
+    instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *,
+};
 use abstract_boot::{AnsHost, ApiDeployer, VCExecFns, VersionControl};
 use abstract_sdk::core::objects::module::{Module, ModuleInfo, ModuleVersion};
 use abstract_sdk::core::{api, ANS_HOST, VERSION_CONTROL};
-use abstract_boot::boot_core::{instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *};
 use cosmwasm_std::{Addr, Empty};
 use cw_staking::boot::CwStakingApi;
 use cw_staking::CW_STAKING;

--- a/contracts/cw-staking/examples/deploy.rs
+++ b/contracts/cw-staking/examples/deploy.rs
@@ -1,7 +1,7 @@
 use abstract_boot::{AnsHost, ApiDeployer, VCExecFns, VersionControl};
 use abstract_sdk::core::objects::module::{Module, ModuleInfo, ModuleVersion};
 use abstract_sdk::core::{api, ANS_HOST, VERSION_CONTROL};
-use boot_core::{instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *};
+use abstract_boot::boot_core::{instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *};
 use cosmwasm_std::{Addr, Empty};
 use cw_staking::boot::CwStakingApi;
 use cw_staking::CW_STAKING;

--- a/contracts/cw-staking/src/lib.rs
+++ b/contracts/cw-staking/src/lib.rs
@@ -20,12 +20,12 @@ pub mod host_staking {
 pub mod boot {
     use crate::msg::{CwStakingAction, CwStakingExecuteMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
     use crate::CW_STAKING;
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, ContractInstance};
+    use abstract_boot::boot_core::{Contract, CwEnv, IndexResponse, TxResponse};
     use abstract_boot::{AbstractBootError, ApiDeployer, Manager};
     use abstract_core::objects::AnsAsset;
     use abstract_core::{api, MANAGER};
-    use abstract_boot::boot_core::ContractWrapper;
-    use abstract_boot::boot_core::{contract, ContractInstance};
-    use abstract_boot::boot_core::{CwEnv, Contract, IndexResponse, TxResponse};
     use cosmwasm_std::{Addr, Empty};
 
     /// Contract wrapper for interacting with BOOT

--- a/contracts/cw-staking/src/lib.rs
+++ b/contracts/cw-staking/src/lib.rs
@@ -23,19 +23,19 @@ pub mod boot {
     use abstract_boot::{AbstractBootError, ApiDeployer, Manager};
     use abstract_core::objects::AnsAsset;
     use abstract_core::{api, MANAGER};
-    use boot_core::ContractWrapper;
-    use boot_core::{boot_contract, ContractInstance};
-    use boot_core::{BootEnvironment, Contract, IndexResponse, TxResponse};
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, ContractInstance};
+    use abstract_boot::boot_core::{CwEnv, Contract, IndexResponse, TxResponse};
     use cosmwasm_std::{Addr, Empty};
 
     /// Contract wrapper for interacting with BOOT
-    #[boot_contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
-    pub struct CwStakingApi<Chain>;
+    #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+    pub struct CwStakingApi;
 
-    impl<Chain: BootEnvironment> ApiDeployer<Chain, Empty> for CwStakingApi<Chain> {}
+    impl<Chain: CwEnv> ApiDeployer<Chain, Empty> for CwStakingApi<Chain> {}
 
     /// implement chain-generic functions
-    impl<Chain: BootEnvironment> CwStakingApi<Chain>
+    impl<Chain: CwEnv> CwStakingApi<Chain>
     where
         TxResponse<Chain>: IndexResponse,
     {

--- a/contracts/cw-staking/tests/common/mod.rs
+++ b/contracts/cw-staking/tests/common/mod.rs
@@ -4,7 +4,7 @@ use abstract_boot::AccountFactory;
 use abstract_boot::AbstractAccount;
 use abstract_core::objects::gov_type::GovernanceDetails;
 
-use boot_core::Mock;
+use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
 pub fn create_default_os(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {

--- a/contracts/cw-staking/tests/stake.rs
+++ b/contracts/cw-staking/tests/stake.rs
@@ -1,16 +1,22 @@
-mod common;
-
 use abstract_boot::{Abstract, ApiDeployer};
 use abstract_core::objects::{AnsAsset, AssetEntry};
-use boot_core::{instantiate_default_mock_env, ContractInstance};
-use boot_core::{CallAs, Deploy};
-use common::create_default_os;
-use cosmwasm_std::{Addr, Empty};
-use cw_staking::CW_STAKING;
-use cw_staking::{boot::CwStakingApi, msg::CwStakingQueryMsgFns};
+use abstract_boot::boot_core::{
+    ContractInstance,
+    instantiate_default_mock_env,
+    Deploy,
+    CallAs
+};
 
+use boot_cw_plus::Cw20ExecuteMsgFns;
+use cosmwasm_std::{Addr, Empty};
 use speculoos::*;
 use wyndex_bundle::{EUR_USD_LP, WYNDEX, WYNDEX_OWNER};
+
+use common::create_default_os;
+use cw_staking::{boot::CwStakingApi, msg::CwStakingQueryMsgFns};
+use cw_staking::CW_STAKING;
+
+mod common;
 
 #[test]
 fn stake_lp() -> anyhow::Result<()> {
@@ -18,7 +24,7 @@ fn stake_lp() -> anyhow::Result<()> {
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
 
     let deployment = Abstract::deploy_on(chain.clone(), "1.0.0".parse()?)?;
-    let wyndex = wyndex_bundle::WynDex::deploy_on(chain.clone(), Empty {})?;
+    let wyndex = wyndex_bundle::WynDex::store_on(chain.clone())?;
 
     let _root_os = create_default_os(&deployment.account_factory)?;
     let mut staking_api = CwStakingApi::new(CW_STAKING, chain.clone());
@@ -33,7 +39,7 @@ fn stake_lp() -> anyhow::Result<()> {
     wyndex
         .eur_usd_lp
         .call_as(&Addr::unchecked(WYNDEX_OWNER))
-        .transfer(1000, proxy_addr.to_string())?;
+        .transfer(1000u128.into(), proxy_addr.to_string())?;
 
     // install exchange on AbstractAccount
     os.manager.install_module(CW_STAKING, &Empty {})?;

--- a/contracts/cw-staking/tests/stake.rs
+++ b/contracts/cw-staking/tests/stake.rs
@@ -1,11 +1,6 @@
+use abstract_boot::boot_core::{instantiate_default_mock_env, CallAs, ContractInstance, Deploy};
 use abstract_boot::{Abstract, ApiDeployer};
 use abstract_core::objects::{AnsAsset, AssetEntry};
-use abstract_boot::boot_core::{
-    ContractInstance,
-    instantiate_default_mock_env,
-    Deploy,
-    CallAs
-};
 
 use boot_cw_plus::Cw20ExecuteMsgFns;
 use cosmwasm_std::{Addr, Empty};
@@ -13,8 +8,8 @@ use speculoos::*;
 use wyndex_bundle::{EUR_USD_LP, WYNDEX, WYNDEX_OWNER};
 
 use common::create_default_os;
-use cw_staking::{boot::CwStakingApi, msg::CwStakingQueryMsgFns};
 use cw_staking::CW_STAKING;
+use cw_staking::{boot::CwStakingApi, msg::CwStakingQueryMsgFns};
 
 mod common;
 

--- a/contracts/dex/Cargo.toml
+++ b/contracts/dex/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dex"
+name = "abstract-dex-api"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
@@ -66,5 +66,5 @@ clap = { workspace = true}
 wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git", branch = "update/0.13.2" }
 abstract-testing = { workspace = true }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
-dex = {path = ".", features = ["boot"]}
+dex = {path = ".", features = ["boot"], package = "abstract-dex-api"}
 boot-cw-plus = { workspace = true }

--- a/contracts/dex/Cargo.toml
+++ b/contracts/dex/Cargo.toml
@@ -63,7 +63,8 @@ speculoos = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 clap = { workspace = true}
-wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git"}
+wyndex-bundle = { git = "https://github.com/Abstract-OS/integration-bundles.git", branch = "update/0.13.2" }
 abstract-testing = { workspace = true }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
 dex = {path = ".", features = ["boot"]}
+boot-cw-plus = { workspace = true }

--- a/contracts/dex/examples/deploy.rs
+++ b/contracts/dex/examples/deploy.rs
@@ -1,7 +1,7 @@
 use abstract_boot::ApiDeployer;
 
-use boot_core::networks::{parse_network, NetworkInfo};
-use boot_core::*;
+use abstract_boot::boot_core::networks::{parse_network, NetworkInfo};
+use abstract_boot::boot_core::*;
 use cosmwasm_std::Decimal;
 use dex::boot::DexApi;
 use dex::msg::DexInstantiateMsg;

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -42,7 +42,8 @@ pub fn execute_handler(
             recipient_os_id,
         } => {
             // only previous OS can change the owner
-            api.account_registry(deps.as_ref()).assert_proxy(&info.sender)?;
+            api.account_registry(deps.as_ref())
+                .assert_proxy(&info.sender)?;
             if let Some(swap_fee) = swap_fee {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
                 fee.set_share(swap_fee)?;

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -42,7 +42,7 @@ pub fn execute_handler(
             recipient_os_id,
         } => {
             // only previous OS can change the owner
-            api.os_registry(deps.as_ref()).assert_proxy(&info.sender)?;
+            api.account_registry(deps.as_ref()).assert_proxy(&info.sender)?;
             if let Some(swap_fee) = swap_fee {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
                 fee.set_share(swap_fee)?;
@@ -51,7 +51,7 @@ pub fn execute_handler(
 
             if let Some(os_id) = recipient_os_id {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
-                let recipient = api.os_registry(deps.as_ref()).proxy_address(os_id)?;
+                let recipient = api.account_registry(deps.as_ref()).proxy_address(os_id)?;
                 fee.set_recipient(deps.api, recipient)?;
                 SWAP_FEE.save(deps.storage, &fee)?;
             }

--- a/contracts/dex/src/handlers/instantiate.rs
+++ b/contracts/dex/src/handlers/instantiate.rs
@@ -12,7 +12,7 @@ pub fn instantiate_handler(
     msg: DexInstantiateMsg,
 ) -> DexResult {
     let recipient = api
-        .os_registry(deps.as_ref())
+        .account_registry(deps.as_ref())
         .proxy_address(msg.recipient_os)?;
     let fee = UsageFee::new(deps.api, msg.swap_fee, recipient)?;
     SWAP_FEE.save(deps.storage, &fee)?;

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -42,7 +42,7 @@ pub mod boot {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)
-                    .with_wasm_path("dex")
+                    .with_wasm_path("abstract_dex_api")
                     .with_mock(Box::new(ContractWrapper::new_with_empty(
                         crate::contract::execute,
                         crate::contract::instantiate,

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -28,17 +28,17 @@ pub mod boot {
         objects::{AnsAsset, AssetEntry},
         MANAGER,
     };
-    use boot_core::ContractWrapper;
-    use boot_core::{boot_contract, BootEnvironment, Contract, ContractInstance};
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, CwEnv, Contract, ContractInstance};
     use cosmwasm_std::{Decimal, Empty};
 
-    #[boot_contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+    #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
     pub struct DexApi<Chain>;
 
     // Implement deployer trait
-    impl<Chain: BootEnvironment> ApiDeployer<Chain, DexInstantiateMsg> for DexApi<Chain> {}
+    impl<Chain: CwEnv> ApiDeployer<Chain, DexInstantiateMsg> for DexApi<Chain> {}
 
-    impl<Chain: BootEnvironment> DexApi<Chain> {
+    impl<Chain: CwEnv> DexApi<Chain> {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -22,14 +22,14 @@ pub mod host_exchange {
 #[cfg(feature = "boot")]
 pub mod boot {
     use crate::{msg::*, EXCHANGE};
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, Contract, ContractInstance, CwEnv};
     use abstract_boot::{AbstractBootError, ApiDeployer, Manager};
     use abstract_core::{
         api::{self},
         objects::{AnsAsset, AssetEntry},
         MANAGER,
     };
-    use abstract_boot::boot_core::ContractWrapper;
-    use abstract_boot::boot_core::{contract, CwEnv, Contract, ContractInstance};
     use cosmwasm_std::{Decimal, Empty};
 
     #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]

--- a/contracts/dex/tests/common/mod.rs
+++ b/contracts/dex/tests/common/mod.rs
@@ -3,7 +3,7 @@ use abstract_boot::AbstractAccount;
 use abstract_boot::AccountFactory;
 use abstract_core::objects::gov_type::GovernanceDetails;
 
-use boot_core::Mock;
+use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
 pub fn create_default_os(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {

--- a/contracts/dex/tests/swap.rs
+++ b/contracts/dex/tests/swap.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use abstract_boot::{Abstract, AbstractAccount, ApiDeployer};
 use abstract_boot::boot_core::Deploy;
 use abstract_boot::boot_core::{instantiate_default_mock_env, ContractInstance};
+use abstract_boot::{Abstract, AbstractAccount, ApiDeployer};
 use common::create_default_os;
 use cosmwasm_std::{coin, Addr, Decimal, Empty};
 use dex::{boot::DexApi, msg::DexInstantiateMsg, EXCHANGE};

--- a/contracts/dex/tests/swap.rs
+++ b/contracts/dex/tests/swap.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use abstract_boot::{Abstract, AbstractAccount, ApiDeployer};
-use boot_core::Deploy;
-use boot_core::{instantiate_default_mock_env, ContractInstance};
+use abstract_boot::boot_core::Deploy;
+use abstract_boot::boot_core::{instantiate_default_mock_env, ContractInstance};
 use common::create_default_os;
 use cosmwasm_std::{coin, Addr, Decimal, Empty};
 use dex::{boot::DexApi, msg::DexInstantiateMsg, EXCHANGE};

--- a/contracts/tendermint-staking/Cargo.toml
+++ b/contracts/tendermint-staking/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tendermint-staking"
+name = "abstract-tendermint-staking-api"
 version = {workspace = true}
 authors = {workspace = true}
 edition = {workspace = true}

--- a/contracts/tendermint-staking/examples/schema.rs
+++ b/contracts/tendermint-staking/examples/schema.rs
@@ -1,7 +1,7 @@
+use abstract_tendermint_staking::contract::TendermintStakeApi;
 use cosmwasm_schema::remove_schemas;
 use std::env::current_dir;
 use std::fs::create_dir_all;
-use tendermint_staking::contract::TendermintStakeApi;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/tendermint-staking/src/lib.rs
+++ b/contracts/tendermint-staking/src/lib.rs
@@ -24,7 +24,7 @@ pub mod boot {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)
-                    .with_wasm_path("tendermint_staking")
+                    .with_wasm_path("abstract_tendermint_staking")
                     .with_mock(Box::new(ContractWrapper::new_with_empty(
                         crate::contract::execute,
                         crate::contract::instantiate,

--- a/contracts/tendermint-staking/src/lib.rs
+++ b/contracts/tendermint-staking/src/lib.rs
@@ -7,10 +7,10 @@ pub const TENDERMINT_STAKING: &str = "abstract:tendermint-staking";
 
 #[cfg(feature = "boot")]
 pub mod boot {
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, Contract, CwEnv};
     use abstract_boot::ApiDeployer;
     use abstract_core::api::InstantiateMsg;
-    use abstract_boot::boot_core::ContractWrapper;
-    use abstract_boot::boot_core::{contract, CwEnv, Contract};
     use cosmwasm_std::Empty;
 
     use crate::msg::*;

--- a/contracts/tendermint-staking/src/lib.rs
+++ b/contracts/tendermint-staking/src/lib.rs
@@ -9,18 +9,18 @@ pub const TENDERMINT_STAKING: &str = "abstract:tendermint-staking";
 pub mod boot {
     use abstract_boot::ApiDeployer;
     use abstract_core::api::InstantiateMsg;
-    use boot_core::ContractWrapper;
-    use boot_core::{boot_contract, BootEnvironment, Contract};
+    use abstract_boot::boot_core::ContractWrapper;
+    use abstract_boot::boot_core::{contract, CwEnv, Contract};
     use cosmwasm_std::Empty;
 
     use crate::msg::*;
 
-    #[boot_contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+    #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
     pub struct TMintStakingApi<Chain>;
 
-    impl<Chain: BootEnvironment> ApiDeployer<Chain, Empty> for TMintStakingApi<Chain> {}
+    impl<Chain: CwEnv> ApiDeployer<Chain, Empty> for TMintStakingApi<Chain> {}
 
-    impl<Chain: BootEnvironment> TMintStakingApi<Chain> {
+    impl<Chain: CwEnv> TMintStakingApi<Chain> {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)


### PR DESCRIPTION
This change updates Abstract APIs to use abstract:0.13.2. 

The reason for doing so is primarily updating traits for dev teams like 4t2.
