### PR TITLE
update dex excute msgs

### DIFF
--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -2,7 +2,7 @@
 // It cannot be in abstract-os because it does not have a dependency on sdk (as it shouldn't)
 use crate::{
     msg::{
-        AskAsset, DexAction, DexApiExecuteMsg, DexExecuteMsg, DexName, DexQueryMsg, OfferAsset,
+        AskAsset, DexAction, DexExecuteMsg, DexName, DexQueryMsg, OfferAsset,
         SimulateSwapResponse, SwapRouter,
     },
     EXCHANGE,
@@ -61,10 +61,10 @@ impl<'a, T: DexInterface> Dex<'a, T> {
 
         modules.request(
             self.dex_module_id(),
-            DexApiExecuteMsg::from(DexExecuteMsg {
+            DexExecuteMsg::Action {
                 dex: self.dex_name(),
                 action,
-            }),
+            },
         )
     }
 

--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -178,7 +178,7 @@ mod test {
         let max_spread = Some(Decimal::percent(1));
         let belief_price = Some(Decimal::percent(2));
 
-        let expected = expected_request_with_test_proxy(DexExecuteMsg {
+        let expected = expected_request_with_test_proxy(DexExecuteMsg::Action {
             dex: dex_name,
             action: DexAction::Swap {
                 offer_asset: offer_asset.clone(),
@@ -222,7 +222,7 @@ mod test {
         let max_spread = Some(Decimal::percent(1));
         let router = Some(SwapRouter::Custom("custom_router".to_string()));
 
-        let expected = expected_request_with_test_proxy(DexExecuteMsg {
+        let expected = expected_request_with_test_proxy(DexExecuteMsg::Action {
             dex: dex_name,
             action: DexAction::CustomSwap {
                 offer_assets: offer_assets.clone(),
@@ -264,7 +264,7 @@ mod test {
         let assets = vec![OfferAsset::new("taco", 1000u128)];
         let max_spread = Some(Decimal::percent(1));
 
-        let expected = expected_request_with_test_proxy(DexExecuteMsg {
+        let expected = expected_request_with_test_proxy(DexExecuteMsg::Action {
             dex: dex_name,
             action: DexAction::ProvideLiquidity {
                 assets: assets.clone(),
@@ -305,7 +305,7 @@ mod test {
         let paired = vec![AssetEntry::new("bell")];
         let _max_spread = Some(Decimal::percent(1));
 
-        let expected = expected_request_with_test_proxy(DexExecuteMsg {
+        let expected = expected_request_with_test_proxy(DexExecuteMsg::Action {
             dex: dex_name,
             action: DexAction::ProvideLiquiditySymmetric {
                 offer_asset: offer.clone(),
@@ -345,7 +345,7 @@ mod test {
         let lp_token = AssetEntry::new("taco");
         let withdraw_amount: Uint128 = 1000u128.into();
 
-        let expected = expected_request_with_test_proxy(DexExecuteMsg {
+        let expected = expected_request_with_test_proxy(DexExecuteMsg::Action {
             dex: dex_name,
             action: DexAction::WithdrawLiquidity {
                 lp_token: lp_token.clone(),

--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -2,8 +2,8 @@
 // It cannot be in abstract-os because it does not have a dependency on sdk (as it shouldn't)
 use crate::{
     msg::{
-        AskAsset, DexAction, DexExecuteMsg, DexName, DexQueryMsg, OfferAsset,
-        SimulateSwapResponse, SwapRouter,
+        AskAsset, DexAction, DexExecuteMsg, DexName, DexQueryMsg, OfferAsset, SimulateSwapResponse,
+        SwapRouter,
     },
     EXCHANGE,
 };

--- a/contracts/dex/src/contract.rs
+++ b/contracts/dex/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::msg::{DexApiExecuteMsg, DexInstantiateMsg, DexQueryMsg};
+use crate::msg::{DexExecuteMsg, DexInstantiateMsg, DexQueryMsg};
 use crate::EXCHANGE;
 use crate::{error::DexError, handlers};
 use abstract_api::{export_endpoints, ApiContract};
@@ -6,7 +6,7 @@ use cosmwasm_std::Response;
 
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub type DexApi = ApiContract<DexError, DexInstantiateMsg, DexApiExecuteMsg, DexQueryMsg>;
+pub type DexApi = ApiContract<DexError, DexInstantiateMsg, DexExecuteMsg, DexQueryMsg>;
 pub type DexResult<T = Response> = Result<T, DexError>;
 
 pub const DEX_API: DexApi = DexApi::new(EXCHANGE, CONTRACT_VERSION, None)

--- a/contracts/dex/src/error.rs
+++ b/contracts/dex/src/error.rs
@@ -58,4 +58,7 @@ pub enum DexError {
 
     #[error("Asset pairing {} not found.", asset_pairing)]
     AssetPairingNotFound { asset_pairing: DexAssetPairing },
+
+    #[error("Invalid Generate Message")]
+    InvalidGenerateMessage,
 }

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -1,6 +1,6 @@
 use crate::error::DexError;
 use crate::exchanges::exchange_resolver;
-use crate::msg::{DexAction, DexApiExecuteMsg, DexExecuteMsg, DexName, IBC_DEX_ID};
+use crate::msg::{DexAction, DexExecuteMsg, DexName, IBC_DEX_ID};
 use crate::LocalDex;
 use crate::{
     contract::{DexApi, DexResult},
@@ -20,14 +20,13 @@ pub fn execute_handler(
     env: Env,
     info: MessageInfo,
     api: DexApi,
-    msg: DexApiExecuteMsg,
+    msg: DexExecuteMsg,
 ) -> DexResult {
     match msg {
-        DexApiExecuteMsg::Request(msg) => {
-            let DexExecuteMsg {
-                dex: dex_name,
-                action,
-            } = msg;
+        DexExecuteMsg::Action {
+            dex: dex_name,
+            action,
+        } => {
             let exchange = exchange_resolver::identify_exchange(&dex_name)?;
             // if exchange is on an app-chain, execute the action on the app-chain
             if exchange.over_ibc() {
@@ -37,7 +36,7 @@ pub fn execute_handler(
                 handle_local_api_request(deps, env, info, api, action, dex_name)
             }
         }
-        DexApiExecuteMsg::UpdateFee {
+        DexExecuteMsg::UpdateFee {
             swap_fee,
             recipient_os_id,
         } => {

--- a/contracts/dex/src/handlers/query.rs
+++ b/contracts/dex/src/handlers/query.rs
@@ -33,7 +33,7 @@ pub fn query_handler(deps: Deps, env: Env, api: &DexApi, msg: DexQueryMsg) -> De
                     let (messages, _) = api.resolve_dex_action(deps, action, exchange)?;
                     to_binary(&GenerateMessagesResponse { messages }).map_err(Into::into)
                 }
-                _ => {}
+                _ => Err(DexError::InvalidGenerateMessage {}),
             }
         }
     }

--- a/contracts/dex/src/handlers/query.rs
+++ b/contracts/dex/src/handlers/query.rs
@@ -20,18 +20,21 @@ pub fn query_handler(deps: Deps, env: Env, api: &DexApi, msg: DexQueryMsg) -> De
             ask_asset,
             dex,
         } => simulate_swap(deps, env, api, offer_asset, ask_asset, dex.unwrap()),
-        DexQueryMsg::GenerateMessages {
-            message: DexExecuteMsg { dex, action },
-        } => {
-            let exchange_id = exchange_resolver::identify_exchange(&dex)?;
-            // if exchange is on an app-chain, execute the action on the app-chain
-            if exchange_id.over_ibc() {
-                return Err(DexError::IbcMsgQuery);
-            }
+        DexQueryMsg::GenerateMessages { message } => {
+            match message {
+                DexExecuteMsg::Action { dex, action } => {
+                    let exchange_id = exchange_resolver::identify_exchange(&dex)?;
+                    // if exchange is on an app-chain, execute the action on the app-chain
+                    if exchange_id.over_ibc() {
+                        return Err(DexError::IbcMsgQuery);
+                    }
 
-            let exchange = exchange_resolver::resolve_exchange(&dex)?;
-            let (messages, _) = api.resolve_dex_action(deps, action, exchange)?;
-            to_binary(&GenerateMessagesResponse { messages }).map_err(Into::into)
+                    let exchange = exchange_resolver::resolve_exchange(&dex)?;
+                    let (messages, _) = api.resolve_dex_action(deps, action, exchange)?;
+                    to_binary(&GenerateMessagesResponse { messages }).map_err(Into::into)
+                }
+                _ => {}
+            }
         }
     }
 }

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -64,7 +64,7 @@ pub mod boot {
 
             let swap_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
                 proxy_address: None,
-                request: DexExecuteMsg {
+                request: DexExecuteMsg::Action {
                     dex,
                     action: DexAction::Swap {
                         offer_asset: AnsAsset::new(asset, offer_asset.1),

--- a/contracts/dex/src/msg.rs
+++ b/contracts/dex/src/msg.rs
@@ -38,7 +38,7 @@ pub enum DexExecuteMsg {
     Action {
         dex: DexName,
         action: DexAction,
-    }
+    },
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/contracts/dex/src/msg.rs
+++ b/contracts/dex/src/msg.rs
@@ -15,11 +15,11 @@ pub type AskAsset = AnsAsset;
 
 pub const IBC_DEX_ID: u32 = 11335;
 
-pub type ExecuteMsg = api::ExecuteMsg<DexApiExecuteMsg>;
+pub type ExecuteMsg = api::ExecuteMsg<DexExecuteMsg>;
 pub type QueryMsg = api::QueryMsg<DexQueryMsg>;
 pub type InstantiateMsg = api::InstantiateMsg<DexInstantiateMsg>;
 
-impl api::ApiExecuteMsg for DexApiExecuteMsg {}
+impl api::ApiExecuteMsg for DexExecuteMsg {}
 impl api::ApiQueryMsg for DexQueryMsg {}
 
 #[cosmwasm_schema::cw_serde]
@@ -30,25 +30,15 @@ pub struct DexInstantiateMsg {
 
 /// Dex Execute msg
 #[cosmwasm_schema::cw_serde]
-pub enum DexApiExecuteMsg {
-    Request(DexExecuteMsg),
+pub enum DexExecuteMsg {
     UpdateFee {
         swap_fee: Option<Decimal>,
         recipient_os_id: Option<u32>,
     },
-}
-
-impl From<DexExecuteMsg> for DexApiExecuteMsg {
-    fn from(action: DexExecuteMsg) -> Self {
-        DexApiExecuteMsg::Request(action)
+    Action {
+        dex: DexName,
+        action: DexAction,
     }
-}
-
-/// Dex Execute msg
-#[cosmwasm_schema::cw_serde]
-pub struct DexExecuteMsg {
-    pub dex: DexName,
-    pub action: DexAction,
 }
 
 #[cosmwasm_schema::cw_serde]


### PR DESCRIPTION
## Flatten Dex and cw-staking API messages

The current API messages have a structure of Base -> ApiRequestMsg -> DexApiExecuteMsg -> DexExecuteMsg -> DexAction
This structure is too nested and confusing. 

We can simplify the type by merging the DexApiExecuteMsg, DexExecuteMsg and  DexAction objects. 

We can provide one top-level API for the dex instead

```rust
DexExecuteMsg {
  UpdateFee {         
  swap_fee: Option<Decimal>,         
  recipient_os_id: Option<u32>,     
  },
  Action {
    exchange: DexName
    action: DexAction
  },
}
```
and feed this top-level struct to the ApiRequestMsg struct.